### PR TITLE
fixing zip suffix name for v0.106.0

### DIFF
--- a/Formula/jbang.rb
+++ b/Formula/jbang.rb
@@ -2,7 +2,7 @@ class Jbang < Formula
   desc "Unleash the power of Java"
   homepage "https://jbang.dev"
   version "0.106.0"
-  url "https://github.com/jbangdev/jbang/releases/download/v0.106.0/jbang-0.106.0.zip"
+  url "https://github.com/jbangdev/jbang/releases/download/v0.106.0/jbang.zip"
   sha256 "50d2cda70fc8e38c65a57a4744bcee9ef34cf55b10b46d8479bc28f4dcf7b2f1"
   license "MIT"
 


### PR DESCRIPTION
for jbang v0.106.0 the release zip file is jbang.zip instead of the referenced jbang-0.106.0.zip which causes a 404